### PR TITLE
Fix enums

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "files.associations": {
+        "iosfwd": "cpp"
+    }
+}

--- a/include/cxxmidi/channel.hpp
+++ b/include/cxxmidi/channel.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+namespace cxxmidi {
+    enum Channel {
+        Channel1 = 0,
+        Channel2,
+        Channel3,
+        Channel4,
+        Channel5,
+        Channel6,
+        Channel7,
+        Channel8,
+        Channel9,
+        Channel10,
+        Channel11,
+        Channel12,
+        Channel13,
+        Channel14,
+        Channel15,
+        Channel16
+    };
+}

--- a/include/cxxmidi/file.hpp
+++ b/include/cxxmidi/file.hpp
@@ -26,8 +26,13 @@ SOFTWARE.
 #include <chrono>  // NOLINT() CPP11_INCLUDES
 #include <cstdint>
 #include <fstream>
+#include <sstream>
 #include <iostream>
 #include <vector>
+#include <functional>
+
+//#include <cxxmidi/guts/endianness.hpp>
+//#include <cxxmidi/guts/utils.hpp>
 
 #include <cxxmidi/track.hpp>
 
@@ -39,6 +44,7 @@ class File : public std::vector<Track> {
   inline explicit File(const char *path);
 
   inline void Load(const char *path);
+  inline void Load(std::istream& stream);
   inline void SaveAs(const char *path) const;
 
   inline Track &AddTrack();
@@ -49,13 +55,15 @@ class File : public std::vector<Track> {
 
   inline std::chrono::microseconds Duration() const;
 
+  inline void SetCallbackLoad(const std::function<bool(Event& event)>& callback);
+
  private:
   uint16_t time_division_;  // [ticks per quarternote]
 
-  inline void ReadHeaderChunk(std::ifstream &file);
-  inline void ReadUnknownChunk(std::ifstream &file);
-  inline void ReadTrackChunk(std::ifstream &file);
-  inline void ReadEvent(std::ifstream &file, Event *event, bool *track_continue,
+  inline void ReadHeaderChunk(std::istream &file);
+  inline void ReadUnknownChunk(std::istream &file);
+  inline void ReadTrackChunk(std::istream &file);
+  inline void ReadEvent(std::istream &file, Event *event, bool *track_continue,
                         uint8_t *running_status);
 
   inline void SaveHeaderChunk(std::ofstream &output_file) const;
@@ -66,6 +74,8 @@ class File : public std::vector<Track> {
 
   inline static uint32_t Write(std::ofstream &file, const uint8_t *c,
                                std::streamsize size = 1);
+
+  std::function<bool(Event& event)> callback_func_load_;
 };
 
 }  // namespace cxxmidi
@@ -117,8 +127,14 @@ void File::SaveTrackChunk(std::ofstream &output_file,
   uint32_t chunk_size = 0;  // chunk size
   uint8_t last_cmd = 0;
 
-  for (const auto &event : track)
+  for (const auto &event : track) {
+      const Message &message = event;
+      if (message.size() > 0) {
     chunk_size += SaveEvent(output_file, event, &last_cmd);
+      } else {
+          // What do we do with a zero-sized message?  Ignore?  Throw an exception?
+      }
+  }
 
   // go back to chunk size
   output_file.seekp(size_pos);
@@ -211,27 +227,37 @@ void File::Load(const char *path) {
     return;
   }
 
+  std::stringstream stream;
+  stream << file.rdbuf();
+
+  Load(stream);
+}
+
+void File::Load(std::istream& stream)
+{
+  clear();
+
   // calculate file length
-  file.seekg(0, std::ifstream::end);
-  auto fileLength = file.tellg();
-  file.seekg(0, std::ifstream::beg);
+  stream.seekg(0, std::istream::end);
+  auto fileLength = stream.tellg();
+  stream.seekg(0, std::istream::beg);
 
   // control counters
   unsigned int i = 0;
   unsigned int headers = 0;
 
   // loop over chunks while data still in buffer
-  while (file.good() && (fileLength - file.tellg())) {
-    uint32_t chunk_id = guts::endianness::ReadBe<uint32_t>(file);
+  while (stream.good() && (fileLength - stream.tellg())) {
+    uint32_t chunk_id = guts::endianness::ReadBe<uint32_t>(stream);
 
     switch (chunk_id) {
       case 0x4D546864:  // "MThd"
-        ReadHeaderChunk(file);
+        ReadHeaderChunk(stream);
         headers++;
         break;
 
       case 0x4D54726B:  // "MTrk"
-        ReadTrackChunk(file);
+        ReadTrackChunk(stream);
         break;
 
       default:
@@ -239,7 +265,7 @@ void File::Load(const char *path) {
         std::cerr << "CxxMidi: ignoring unknown chunk: 0x" << std::hex
                   << static_cast<int>(chunk_id) << std::endl;
 #endif
-        ReadUnknownChunk(file);
+        ReadUnknownChunk(stream);
         break;
     }
 
@@ -254,7 +280,7 @@ void File::Load(const char *path) {
   }
 }
 
-void File::ReadHeaderChunk(std::ifstream &file) {
+void File::ReadHeaderChunk(std::istream &file) {
   // read and check header size
   if (guts::endianness::ReadBe<uint32_t>(file) != 6) {
 #ifndef CXXMIDI_QUIET
@@ -291,7 +317,7 @@ void File::ReadHeaderChunk(std::ifstream &file) {
 #endif
 }
 
-void File::ReadUnknownChunk(std::ifstream &file) {
+void File::ReadUnknownChunk(std::istream &file) {
   // get chunk size
   uint32_t chunk_size = guts::endianness::ReadBe<uint32_t>(file);
 
@@ -299,9 +325,11 @@ void File::ReadUnknownChunk(std::ifstream &file) {
   file.seekg(chunk_size, std::ifstream::cur);
 }
 
-void File::ReadTrackChunk(std::ifstream &file) {
+void File::ReadTrackChunk(std::istream &file) {
   // push back new track
   Track &track = AddTrack();
+
+  uint32_t dtAdd = 0;
 
   // read track chunk size
   uint32_t chunk_size = guts::endianness::ReadBe<uint32_t>(file);
@@ -313,13 +341,31 @@ void File::ReadTrackChunk(std::ifstream &file) {
 
   // read track data
   while (track_continue) {
+    int initialTrackSize = track.size();
+
     Event &event = track.AddEvent();
 
     uint32_t dt = utils::GetVlq(file);  // get delta time
-    event.SetDt(dt);                    // save event delta time
+    event.SetDt(dt + dtAdd);            // save event delta time
+    dtAdd = 0;                          // Reset dtAdd
 
     // read event data
     ReadEvent(file, &event, &track_continue, &running_status);
+
+
+    // Call Load callback, sending the newly read Event.  
+    bool load = true;   // Load events to track by default
+
+    if (callback_func_load_)
+    {
+      load = callback_func_load_(event);  // Call the event callback
+    }
+
+    if (!load) {
+        // Save the DT of track.back() and add it to the DT of the next event.
+        dtAdd = track.back().Dt();
+        track.pop_back();   // if directed not to load, remove the newly added event
+    }
   }
 
 #ifndef CXXMIDI_QUIET
@@ -329,7 +375,7 @@ void File::ReadTrackChunk(std::ifstream &file) {
 #endif
 }
 
-void File::ReadEvent(std::ifstream &file, Event *event, bool *track_continue,
+void File::ReadEvent(std::istream &file, Event *event, bool *track_continue,
                      uint8_t *running_status) {
   uint8_t cmd = guts::endianness::ReadBe<uint8_t>(file);
 
@@ -433,10 +479,10 @@ void File::ReadEvent(std::ifstream &file, Event *event, bool *track_continue,
                 event->push_back(guts::endianness::ReadBe<uint8_t>(file));
             } break;
             default: {
-#ifndef CXXMIDI_QUIET
-              std::cerr << "CxxMidi: unknown meta event 0x" << std::hex
-                        << meta_event_type << std::endl;
-#endif
+              // Ignore non-standard Meta events - just pass them through
+              uint8_t strLength = guts::endianness::ReadBe<uint8_t>(file);
+              for (int i = 0; i < strLength; i++)
+                event->push_back(guts::endianness::ReadBe<uint8_t>(file));
             } break;
           }  // switch meta_event_type
           break;
@@ -457,6 +503,11 @@ void File::ReadEvent(std::ifstream &file, Event *event, bool *track_continue,
 #endif
       break;
   }
+}
+
+
+void File::SetCallbackLoad(const std::function<bool(Event& event)>& callback) {
+  callback_func_load_ = callback;
 }
 
 }  // namespace cxxmidi

--- a/include/cxxmidi/file.hpp
+++ b/include/cxxmidi/file.hpp
@@ -31,8 +31,8 @@ SOFTWARE.
 #include <vector>
 #include <functional>
 
-//#include <cxxmidi/guts/endianness.hpp>
-//#include <cxxmidi/guts/utils.hpp>
+#include <cxxmidi/guts/endianness.hpp>
+#include <cxxmidi/guts/utils.hpp>
 
 #include <cxxmidi/track.hpp>
 
@@ -80,9 +80,7 @@ class File : public std::vector<Track> {
 
 }  // namespace cxxmidi
 
-#include <cxxmidi/guts/endianness.hpp>
 #include <cxxmidi/guts/simulator.hpp>
-#include <cxxmidi/guts/utils.hpp>
 
 namespace cxxmidi {
 

--- a/include/cxxmidi/guts/endianness.hpp
+++ b/include/cxxmidi/guts/endianness.hpp
@@ -83,6 +83,14 @@ T ReadBe(std::ifstream &file) {
 }
 
 template <typename T>
+T ReadBe(std::istream &file) {
+  T r;
+  file.read(reinterpret_cast<char *>(&r), sizeof(T));
+  if ((sizeof(T) > 1) && MachineIsLittleEndian()) r = Swap<T>(r);
+  return r;
+}
+
+template <typename T>
 size_t WriteBe(std::ofstream &file, T val) {
   size_t size = sizeof(val);
   if ((sizeof(T) > 1) && MachineIsLittleEndian()) val = Swap<T>(val);

--- a/include/cxxmidi/guts/utils.hpp
+++ b/include/cxxmidi/guts/utils.hpp
@@ -61,6 +61,18 @@ inline uint32_t GetVlq(std::ifstream &file) {
   return r;
 }
 
+inline uint32_t GetVlq(std::istream &file) {
+  uint32_t r = 0;
+  uint8_t c;
+
+  do {
+    file.read(reinterpret_cast<char *>(&c), 1);
+    r = (r << 7) + (c & 0x7f);
+  } while (c & 0x80);
+
+  return r;
+}
+
 inline size_t SaveVlq(std::ofstream &output_file, unsigned int val) {
   size_t r = 0;
   uint32_t vlq = val & 0x7f;

--- a/include/cxxmidi/message.hpp
+++ b/include/cxxmidi/message.hpp
@@ -66,6 +66,7 @@ class Message : public std::vector<uint8_t> {
 
   enum MetaType {
     kSequenceNumber = 0x00,  // size 2
+    // The following meta events have variable size: len text
     kText = 0x01,
     kCopyright = 0x02,
     kTrackName = 0x03,
@@ -73,6 +74,9 @@ class Message : public std::vector<uint8_t> {
     kLyrics = 0x05,
     kMarker = 0x06,
     kCuePoint = 0x07,
+    kProgramName = 0x08,  // RP-019 Program Name Meta Event
+    kDeviceName = 0x09,   // RP-019 Device Name Meta Event
+    // End len text meta events
     kChannelPrefix = 0x20,  // size 1
     kOutputCable = 0x21,    // size 1
     kEndOfTrack = 0x2f,     // size 0
@@ -195,6 +199,10 @@ std::string Message::GetName() const {
         return "Marker";
       case kCuePoint:
         return "CuePoint";
+      case kProgramName:
+        return "ProgramName";
+      case kDeviceName:
+        return "DeviceName";
       case kChannelPrefix:
         return "ChannelPrefix";
       case kOutputCable:

--- a/include/cxxmidi/message.hpp
+++ b/include/cxxmidi/message.hpp
@@ -164,11 +164,13 @@ bool Message::IsSystemCommon() const {
 }
 
 bool Message::ContainsText() const {
-  if (size() > 1)
-    return ((*this)[0] == 0xff) &&
-           (((*this)[1] == kText) || ((*this)[1] == kLyrics) ||
-            ((*this)[1] == kInstrumentName) || ((*this)[1] == kTrackName) ||
-            ((*this)[1] == kCopyright));
+  if (size() > 1) {
+    return (
+            (*this)[0] == 0xff &&
+            (*this)[1] >= kText && 
+            (*this)[1] <= kDeviceName
+           );
+  }
   return false;
 }
 

--- a/include/cxxmidi/message.hpp
+++ b/include/cxxmidi/message.hpp
@@ -33,58 +33,98 @@ class Message : public std::vector<uint8_t> {
  public:
   enum Type {
     kUndefined = 0x00,
+    Undefined = kUndefined,
 
     // voice
     kNoteOff = 0x80,
+    NoteOff = kNoteOff,
     kNoteOn = 0x90,
+    NoteOn = kNoteOn,
     kNoteAftertouch = 0xa0,
+    NoteAftertouch = kNoteAftertouch,
     kControlChange = 0xb0,
+    ControlChange = kControlChange,
     kProgramChange = 0xc0,      // size 1
+    ProgramChange = kProgramChange,
     kChannelAftertouch = 0xd0,  // size 1
+    ChannelAftertouch = kChannelAftertouch,
     kPitchWheel = 0xe0,
+    PitchWheel = kPitchWheel,
 
     // system common
     kSysExBegin = 0xf0,
+    SysExBegin = kSysExBegin,
     kMtcQuarterFrame = 0xf1,
+    MtcQuarterFrame = kMtcQuarterFrame,
     kSongPositionPointer = 0xf2,
+    SongPositionPointer = kSongPositionPointer,
     kSongSelect = 0xf3,
+    SongSelect = kSongSelect,
     kTuneRequest = 0xf6,
+    TuneRequest = kTuneRequest,
     kSysExEnd = 0xf7,
+    SysExEnd = kSysExEnd,
 
     // realtime
     kClock = 0xf8,
+    Clock = kClock,
     kTick = 0xf9,
+    Tick = kTick,
     kStart = 0xfa,
+    Start = kStart,
     kContinue = 0xfb,
+    Continue = kContinue,
     kStop = 0xfc,
+    Stop = kStop,
     kActiveSense = 0xfe,
+    ActiveSense = kActiveSense,
     kReset = 0xff,
+    Reset = kReset,
 
     // Meta events
-    kMeta = 0xff
+    kMeta = 0xff,
+    Meta = kMeta
   };
 
   enum MetaType {
     kSequenceNumber = 0x00,  // size 2
+    SequenceNumber = kSequenceNumber,
     // The following meta events have variable size: len text
     kText = 0x01,
+    Text = kText,
     kCopyright = 0x02,
+    Copyright = kCopyright,
     kTrackName = 0x03,
+    TrackName = kTrackName,
     kInstrumentName = 0x04,
+    InstrumentName = kInstrumentName,
     kLyrics = 0x05,
+    Lyrics = kLyrics,
     kMarker = 0x06,
+    Marker = kMarker,
     kCuePoint = 0x07,
+    CuePoint = kCuePoint,
     kProgramName = 0x08,  // RP-019 Program Name Meta Event
+    ProgramName = kProgramName,
     kDeviceName = 0x09,   // RP-019 Device Name Meta Event
+    DeviceName = kDeviceName,
     // End variable size text meta events
     kChannelPrefix = 0x20,  // size 1
+    ChannelPrefix = kChannelPrefix,
     kOutputCable = 0x21,    // size 1
+    OutputCable = kOutputCable,
     kEndOfTrack = 0x2f,     // size 0
+    EndOfTrack = kEndOfTrack,
     kTempo = 0x51,          // size 3
+    Tempo = kTempo,
     kSmpteOffset = 0x54,    // size 5
+    SmpteOffset = kSmpteOffset,
     kTimeSignature = 0x58,
+    TimeSignature = kTimeSignature,
     kKeySignature = 0x59,
-    kSequencerSpecific = 0x7f  // variable size
+    KeySignature = kKeySignature,
+    kSequencerSpecific = 0x7f,  // variable size
+    SequencerSpecific = kSequencerSpecific
   };
 
   Message() = default;

--- a/include/cxxmidi/message.hpp
+++ b/include/cxxmidi/message.hpp
@@ -83,7 +83,8 @@ class Message : public std::vector<uint8_t> {
     kTempo = 0x51,          // size 3
     kSmpteOffset = 0x54,    // size 5
     kTimeSignature = 0x58,
-    kKeySignature = 0x59
+    kKeySignature = 0x59,
+    kSequencerSpecific = 0x7f  // variable size
   };
 
   Message() = default;

--- a/include/cxxmidi/message.hpp
+++ b/include/cxxmidi/message.hpp
@@ -66,6 +66,7 @@ class Message : public std::vector<uint8_t> {
 
   enum MetaType {
     kSequenceNumber = 0x00,  // size 2
+    // The following meta events have variable size: len text
     kText = 0x01,
     kCopyright = 0x02,
     kTrackName = 0x03,
@@ -73,6 +74,9 @@ class Message : public std::vector<uint8_t> {
     kLyrics = 0x05,
     kMarker = 0x06,
     kCuePoint = 0x07,
+    kProgramName = 0x08,  // RP-019 Program Name Meta Event
+    kDeviceName = 0x09,   // RP-019 Device Name Meta Event
+    // End variable size text meta events
     kChannelPrefix = 0x20,  // size 1
     kOutputCable = 0x21,    // size 1
     kEndOfTrack = 0x2f,     // size 0
@@ -160,11 +164,13 @@ bool Message::IsSystemCommon() const {
 }
 
 bool Message::ContainsText() const {
-  if (size() > 1)
-    return ((*this)[0] == 0xff) &&
-           (((*this)[1] == kText) || ((*this)[1] == kLyrics) ||
-            ((*this)[1] == kInstrumentName) || ((*this)[1] == kTrackName) ||
-            ((*this)[1] == kCopyright));
+  if (size() > 1) {
+    return (
+            (*this)[0] == 0xff &&
+            (*this)[1] >= kText && 
+            (*this)[1] <= kDeviceName
+           );
+  }
   return false;
 }
 
@@ -195,6 +201,10 @@ std::string Message::GetName() const {
         return "Marker";
       case kCuePoint:
         return "CuePoint";
+      case kProgramName:
+        return "ProgramName";
+      case kDeviceName:
+        return "DeviceName";
       case kChannelPrefix:
         return "ChannelPrefix";
       case kOutputCable:

--- a/merge_ecomidi.md
+++ b/merge_ecomidi.md
@@ -1,0 +1,6 @@
+- [x] channel.hpp 
+- [x] endianness.hpp  
+- [x] file.hpp  
+- [x] player_base.hpp  
+- [x] player_sync.hpp 
+- [x] utils.hpp


### PR DESCRIPTION
Create enum constant names without the 'k' prefix for clarity, neatness, and readability.